### PR TITLE
Feature/fix refs using refparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ You can also check the test cases, every feature is tested.
 ### Schema Support
 
 The package is focused on supporting JSON schema draft-06 files, since this is
-the target TypeBox officially supports. From typebox repo "These types are fully
-compatible with the JSON Schema Draft 6 specification."
+the target TypeBox officially supports. Quote from typebox repo "These types are
+fully compatible with the JSON Schema Draft 6 specification."
 
 However, since the amount of breaking changes is quite small between most JSON
 schema specs, support for other specs may "just work" or may be implemented at a
@@ -204,21 +204,13 @@ whats already implemented and what is missing.
     info](https://github.com/xddq/schema2typebox/issues/16).
 - [x] SchemaOptions for everything that is implemented
 - [x] Type.Enum() via "enum" property
-  - NOTE: Interesting that Type.Enum() creates a json schema with a list of
-    anyOf consts instead of enum.
-- [x] $ref to other schema files via relative path
-- [x] name of generated value and type based on "title" attribute
-  - are there other attributes one should check if "title" is undefined?
-- [ ] (low prio?) $ref to definitions inside the current schema
-  - NOTE: perhaps wait and see if people mention the need
-  - Initial idea to implement this via collecting all $defs in a "preprocessing"
-    step inside a map and whenever we get a $ref we query the map to insert the
-    correct type.
-- [ ] (low prio) $ref to remote schemas
+- [x] $refs anywhere using [@apidevtools/json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser)
+- [x] Name of generated value and type based on existing "title" attribute.
+      Defaulting to "T" if title is not defined.
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
 - [ ] (low prio) Type.Not() via "not" property
-  - TODO: Is this even possible? I am confused.
+  - TODO: Is this even possible?
 
 ## DEV/CONTRIBUTOR NOTES
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ Happy about contributions if you want to implement it yourself.
 - [x] draft-06 (main goal of this package, see Feature List for the state)
 - [x] draft-07
 - [x] draft-2019-09
-  - should be working with the _current feature set_
 - [ ] draft-2020-12
   - Probably not working due to new keywords or semantic changes for previous
     keywords. Happy about issues with your JSON schema, expected TypeBox code
@@ -197,20 +196,19 @@ whats already implemented and what is missing.
 - [x] Type.Literal() via "const" property
 - [x] Type.Union() via "anyOf" property
 - [x] Type.Intersect() via "allOf" property
-- [x] Type.oneOf() via "oneOf" property
+- [x] Type.Enum() via "enum" property
+- [x] oneOf() via "oneOf" property
   - This adds oneOf to the typebox type registry as (Kind: 'ExtendedOneOf') in
     order to be able to align to oneOf json schema semantics and still be able
     to use the typebox compiler. [More
     info](https://github.com/xddq/schema2typebox/issues/16).
-- [x] SchemaOptions for everything that is implemented
-- [x] Type.Enum() via "enum" property
+- [x] schemaOptions
 - [x] $refs anywhere using [@apidevtools/json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser)
 - [x] Name of generated value and type based on existing "title" attribute.
       Defaulting to "T" if title is not defined.
+- [ ] Type.Not() via "not" property
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
-- [ ] (low prio) Type.Not() via "not" property
-  - TODO: Is this even possible?
 
 ## DEV/CONTRIBUTOR NOTES
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Happy about contributions if you want to implement it yourself.
 - [x] draft-06 (main goal of this package, see Feature List for the state)
 - [x] draft-07
 - [x] draft-2019-09
+- should be working with the _current feature set_
 - [ ] draft-2020-12
   - Probably not working due to new keywords or semantic changes for previous
     keywords. Happy about issues with your JSON schema, expected TypeBox code

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cli"
   ],
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "9.0.9",
     "@sinclair/typebox": "0.28.10",
     "cosmiconfig": "8.1.3",
     "minimist": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema2typebox",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/src/index.js",
   "description": "Creates typebox code from JSON schemas",
   "source": "dist/src/index.js",

--- a/src/programmatic-usage.ts
+++ b/src/programmatic-usage.ts
@@ -22,7 +22,7 @@ export type Schema2TypeboxOptions = {
 export const schema2typebox = async ({
   input,
 }: Schema2TypeboxOptions): Promise<string> => {
-  const generatedTypeboxCode = Schema2Typebox(input);
+  const generatedTypeboxCode = await Schema2Typebox(input);
 
   // TODO: create a "pipeline" for processing
   // post-processing

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -190,7 +190,6 @@ export const collect = (
     },
     {}
   );
-  const isTypeLiteral = schemaOptions["const"] !== undefined;
   const isRequiredAttribute = requiredAttributes.includes(
     propertyName ?? "__NO_MATCH__"
   );
@@ -322,6 +321,7 @@ export const collect = (
   ) {
     // console.log("type was string or number or null or boolean");
 
+    const isTypeLiteral = schemaOptions["const"] !== undefined;
     if (isArrayItem) {
       if (isTypeLiteral) {
         const resultingType = mapTypeLiteral(
@@ -511,7 +511,8 @@ const getType = (schemaObj: Record<string, any>): VALID_TYPE_VALUE => {
 
   if (!VALID_TYPE_VALUES.includes(type)) {
     throw new Error(
-      `JSON schema had invalid value for 'type' attribute. Got: ${type}`
+      `JSON schema had invalid value for 'type' attribute. Got: ${type}
+      Schemaobject was: ${JSON.stringify(schemaObj)}`
     );
   }
 

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs";
 import { zip } from "./utils";
+import $Refparser from "@apidevtools/json-schema-ref-parser";
 
 /** Generates TypeBox code from JSON schema */
-export const schema2typebox = (jsonSchema: string) => {
+export const schema2typebox = async (jsonSchema: string) => {
   const schemaObj = JSON.parse(jsonSchema);
-  const typeBoxType = collect(schemaObj, []);
+  const dereferencedSchemaObj = await $Refparser.dereference(schemaObj);
+  const typeBoxType = collect(dereferencedSchemaObj, []);
   // TODO: Are there alternative attributes people use for naming the entities?
-  const valueName = schemaObj["title"] ?? "T";
+  const valueName = dereferencedSchemaObj["title"] ?? "T";
   const typeForObj = generateTypeForName(valueName);
 
   const normalImportStatements = `import { Type, Static } from "@sinclair/typebox";`;

--- a/tmp/cat.json
+++ b/tmp/cat.json
@@ -1,0 +1,15 @@
+{
+  "title": "Cat",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "cat"
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 100
+    }
+  },
+  "required": ["type", "name"]
+}

--- a/tmp/dog.json
+++ b/tmp/dog.json
@@ -1,0 +1,15 @@
+{
+  "title": "Dog",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "dog"
+    },
+    "name": {
+      "type": "string",
+      "maxLength": 100
+    }
+  },
+  "required": ["type", "name"]
+}

--- a/tmp/schema.json
+++ b/tmp/schema.json
@@ -1,0 +1,3 @@
+{
+  "anyOf": [{ "$ref": "./cat.json" }, { "$ref": "./dog.json" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,18 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@apidevtools/json-schema-ref-parser@npm:9.0.9":
+  version: 9.0.9
+  resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
+  dependencies:
+    "@jsdevtools/ono": ^7.1.3
+    "@types/json-schema": ^7.0.6
+    call-me-maybe: ^1.0.1
+    js-yaml: ^4.1.0
+  checksum: b21f6bdd37d2942c3967ee77569bc74fadd1b922f688daf5ef85057789a2c3a7f4afc473aa2f3a93ec950dabb6ef365f8bd9cf51e4e062a1ee1e59b989f8f9b4
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0":
   version: 7.21.4
   resolution: "@babel/code-frame@npm:7.21.4"
@@ -269,6 +281,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsdevtools/ono@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "@jsdevtools/ono@npm:7.1.3"
+  checksum: 2297fcd472ba810bffe8519d2249171132844c7174f3a16634f9260761c8c78bc0428a4190b5b6d72d45673c13918ab9844d706c3ed4ef8f62ab11a2627a08ad
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -344,6 +363,13 @@ __metadata:
     "@types/minimatch": "*"
     "@types/node": "*"
   checksum: 6ae717fedfdfdad25f3d5a568323926c64f52ef35897bcac8aca8e19bc50c0bd84630bbd063e5d52078b2137d8e7d3c26eabebd1a2f03ff350fff8a91e79fc19
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.6":
+  version: 7.0.12
+  resolution: "@types/json-schema@npm:7.0.12"
+  checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
   languageName: node
   linkType: hard
 
@@ -734,6 +760,13 @@ __metadata:
     tar: ^6.1.11
     unique-filename: ^2.0.0
   checksum: d91409e6e57d7d9a3a25e5dcc589c84e75b178ae8ea7de05cbf6b783f77a5fae938f6e8fda6f5257ed70000be27a681e1e44829251bfffe4c10216002f8f14e6
+  languageName: node
+  linkType: hard
+
+"call-me-maybe@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "call-me-maybe@npm:1.0.2"
+  checksum: 42ff2d0bed5b207e3f0122589162eaaa47ba618f79ad2382fe0ba14d9e49fbf901099a6227440acc5946f86a4953e8aa2d242b330b0a5de4d090bb18f8935cae
   languageName: node
   linkType: hard
 
@@ -2388,6 +2421,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "schema2typebox@workspace:."
   dependencies:
+    "@apidevtools/json-schema-ref-parser": 9.0.9
     "@sinclair/typebox": 0.28.10
     "@tsconfig/node18": 2.0.0
     "@types/minimist": 1.2.2


### PR DESCRIPTION
## Summary

Implements using $refs using [@apidevtools/json-schema-ref-parser](https://github.com/APIDevTools/json-schema-ref-parser). Implements missing features to support remote refs and definitions.
