### PR TITLE
feat: improve support for Enum types, Nullable Literals, Unknowns, etc

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+export const capitalize = (name: string) => {
+  const [head, ...tail] = name;
+  if (head === undefined) {
+    return name;
+  }
+  return `${head.toUpperCase()}${tail.join("")}`;
+};


### PR DESCRIPTION
## Summary
I'm in the process of migrating our mongoose schemas to TypeBox as a part of our recent upgrade to Feathers v5. Our data model contains over 100 mongoose schemas with a large variety in usage including child schemas, discriminated types, enums, and much more. This PR is the end result of my local updates to the library to get our schemas generated

### Process
I wrote a crude ts script to either take a service name, or map over all service directories. For each service it does the following:

1. load the mongoose model and schema
2. use the [mongoose-schema-jsonschema](https://github.com/DScheglov/mongoose-schema-jsonschema) library to extract the json-schema representation of the mongoose schema
3. pipe the json-schema into ~~ts2typebox~~ `schema2typebox`
4. write the result to `services/${serviceName}/schema.ts`

### Changes
- feat: initial support for Type.Union vs Type.Enum
- feat: add support for arrays of enum types
- feat: add support for "unknown" object types with no properties
- fix: improve support for nullable literal types (eg: `type: ['string', 'null']`)
- chore: begin work on disambiguation of nested Enum/Union types
- chore: update errors to include property name where error was thrown
- refactor: break out some utils into separate file

### TODO
- [ ] Test coverage
- [ ] Documentation
- [ ] Break apart if necessary