### PR TITLE
feat!: default to union types and preserve configurability for enum, union or both

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ whats already implemented and what is missing.
 - [x] Type.Literal() via "const" property
 - [x] Type.Union() via "anyOf" property
 - [x] Type.Intersect() via "allOf" property
-- [x] Type.Enum() via "enum" property
+- [x] Type.Union() via "enum" property
 - [x] OneOf() via "oneOf" property
   - This adds oneOf to the typebox type registry as (Kind: 'ExtendedOneOf') in
     order to be able to align to oneOf json schema semantics and still be able
@@ -210,6 +210,14 @@ whats already implemented and what is missing.
       Defaulting to "T" if title is not defined.
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
+
+#### To Be Prioritized
+Support for the following types and functionality is being split from PR #23 into individual PRs
+- [ ] Type.Enum() via "enum" property
+- [ ] Type.Array() with "array<enum>" instance type
+- [ ] Nullable Literal types, eg: `type: ['string', 'null']`
+- [ ] "Unknown" object types
+- [ ] Disambiguation of overlapping property names in nested schemas
 
 ## DEV/CONTRIBUTOR NOTES
 

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { zip } from "fp-ts/Array";
 import $Refparser from "@apidevtools/json-schema-ref-parser";
+import { capitalize } from "./utils";
 
 /** Generates TypeBox code from JSON schema */
 export const schema2typebox = async (jsonSchema: string) => {
@@ -18,16 +19,11 @@ ${customTypes}${enumCode}${typeForObj}\nexport const ${valueName} = ${typeBoxTyp
 };
 
 const generateTypeForName = (name: string) => {
-  const [head, ...tail] = name;
-  if (head === undefined) {
+  if (!name?.length) {
     throw new Error(`Can't generate type for empty string. Got input: ${name}`);
   }
-  if (tail.length === 0) {
-    return `export type ${head.toUpperCase()} = Static<typeof ${name}>`;
-  }
-  return `export type ${head.toUpperCase()}${tail.join(
-    ""
-  )} = Static<typeof ${name}>`;
+  const typeName = capitalize(name);
+  return `export type ${typeName} = Static<typeof ${name}>`;
 };
 
 /**
@@ -121,11 +117,10 @@ const isNotSchemaObj = (
 };
 
 const createEnumName = (propertyName: string) => {
-  const [head, ...tail] = propertyName;
-  if (head === undefined) {
+  if (!propertyName?.length) {
     throw new Error("Can't create enum name with empty string.");
   }
-  return `${head.toUpperCase()}${tail.join("")}Enum`;
+  return `${capitalize(propertyName)}Enum`;
 };
 
 /**

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -141,6 +141,13 @@ export const resetEnumCode = () => {
 };
 
 /**
+ * Used to programatically retrieve the enum code. Used in tests.
+ */
+export const getEnumCode = () => {
+  return enumCode;
+};
+
+/**
  * Adds custom types to the typebox registry in order to validate them and use
  * the typecompiler against them. Used to e.g. implement 'oneOf' which does
  * normally not exist in typebox. This code has the drawback that is does not
@@ -231,19 +238,19 @@ export const collect = (
     );
     const pairs = zip(enumKeys, enumValues);
 
-    const enumName = createEnumName(propertyName);
     // create typescript enum
+    const enumName = createEnumName(propertyName);
     const enumInTypescript =
-    pairs.reduce<string>((prev, [enumKey, enumValue]) => {
-      const correctEnumValue =
-      typeof enumValue === "string" ? `"${enumValue}"` : enumValue;
-      const validEnumKey =
-      enumKey === "" ? "EMPTY_STRING" : enumKey.replace(/[-]/g, "_");
-      return `${prev}${validEnumKey} = ${correctEnumValue},\n`;
-    }, `export enum ${enumName} {\n`) + "}";
+      pairs.reduce<string>((prev, [enumKey, enumValue]) => {
+        const correctEnumValue =
+          typeof enumValue === "string" ? `"${enumValue}"` : enumValue;
+        const validEnumKey =
+          enumKey === "" ? "EMPTY_STRING" : enumKey.replace(/[-]/g, "_");
+        return `${prev}${validEnumKey} = ${correctEnumValue},\n`;
+      }, `export enum ${enumName} {\n`) + "}";
 
     // create typescript union
-    const unionName = createUnionName(propertyName || itemPropertyName || "");
+    const unionName = createUnionName(propertyName);
     const unionInTypescript =
       enumValues.reduce((prev, enumValue) => {
         const correctEnumValue =
@@ -254,8 +261,9 @@ export const collect = (
 
     enumCode = [
       enumCode,
-      /enum/i.test(enumMode) && enumInTypescript,
-      /union/i.test(enumMode) && unionInTypescript,
+      /enum|prefer/i.test(enumMode) && enumInTypescript,
+      /prefer/i.test(enumMode) && "\n",
+      /union|prefer/i.test(enumMode) && unionInTypescript,
       "\n\n",
     ]
       .filter((x) => !!x)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * @name capitalize
+ * @description
+ * Capitalize the first letter of a string
+ * @returns {string} The capitalized string
+ */
+export const capitalize = (name: string) => {
+  const [head, ...tail] = name;
+  if (head === undefined) {
+    return name;
+  }
+  return `${head.toUpperCase()}${tail.join("")}`;
+};


### PR DESCRIPTION
## Summary
Split from my PR #23, this PR focuses on changing the default behavior of `schema2typebox` from generating TypeBox `Enum` types to defaulting to TypeBox `Union` types. This is inline with the typescript community which has shifted to using union types over enums.

## Example

<table>
<thead><tr><td>schema</td><td>enum mode</td><td>union mode</td></tr></thead>
<tbody>
<tr>
<td>

```
{
  "type": "object",
  "properties": {
    "status": {
    "enum": [
        "unknown",
        "accepted", 
        "denied"
    ]}
  }, 
  "required": ["status"]
}
```

</td>
<td>

```
export enum StatusEnum {
  UNKNOWN = "unknown",
  ACCEPTED = "accepted",
  DENIED = "denied",
}

Type.Object({
  status: Type.Enum(StatusEnum),
})
```

</td>
<td>

```
export const StatusUnion = Type.Union([
  Type.Literal("unknown"),
  Type.Literal("accepted"),
  Type.Literal("denied"),
])

Type.Object({
  status: StatusUnion,
}) 
```

</td>
</tr>
</tbody>
</table>

## Checklist
- [x] new code is covered by test suite
- [x] example schema included in PR description
- [x] update README to reflect changes

## Discussion & Open Questions

### Configurability
I agree with the goal of keeping the number of configuration options to a minimum, but I have to say that I have found it incredibly useful to have control over things like this. While not rising to the level of debate seen on other topics, I think choosing one or the other alienates potential users unnecessarily. I have felt this pressure internally, and while I haven't migrated our entire codebase, I believe there are some scenarios where I will face resistance if I don't generate an Enum type.