### PR TITLE
Union type preference by pdfowler

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ whats already implemented and what is missing.
 - [x] Type.Array() via "array" instance type
 - [x] Type.Object() via "object" instance type
 - [x] Type.Literal() via "const" property
-- [x] Type.Union() via "anyOf" property
+- [x] Type.Union() via "anyOf" or "enum" property
+  - schema2typebox generates union types instead of enums. If you have a problem
+    with this behaviour and valid arguments for using enums please create an
+    issue and it may be considered again.
 - [x] Type.Intersect() via "allOf" property
-- [x] Type.Union() via "enum" property
 - [x] OneOf() via "oneOf" property
   - This adds oneOf to the typebox type registry as (Kind: 'ExtendedOneOf') in
     order to be able to align to oneOf json schema semantics and still be able
@@ -211,9 +213,10 @@ whats already implemented and what is missing.
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
 
-#### To Be Prioritized
-Support for the following types and functionality is being split from PR #23 into individual PRs
-- [ ] Type.Enum() via "enum" property
+#### Open Tasks
+
+See [here](https://github.com/xddq/schema2typebox/pull/23) and followup PRs.
+
 - [ ] Type.Array() with "array<enum>" instance type
 - [ ] Nullable Literal types, eg: `type: ['string', 'null']`
 - [ ] "Unknown" object types

--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ Creating TypeBox code from JSON schemas.
 // Which becomes..
 //
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });
 
 //
@@ -136,19 +136,19 @@ export const Person = Type.Object({
 // Will result in this:
 //
 
-export enum StatusEnum {
-  UNKNOWN = "unknown",
-  ACCEPTED = "accepted",
-  DENIED = "denied",
-}
-
 export type Contract = Static<typeof Contract>;
 export const Contract = Type.Object({
   person: Type.Object({
     name: Type.String({ maxLength: 100 }),
     age: Type.Number({ minimum: 18 }),
   }),
-  status: Type.Optional(Type.Enum(StatusEnum)),
+  status: Type.Optional(
+      Type.Union([
+        Type.Literal("unknown"),
+        Type.Literal("accepted"),
+        Type.Literal("denied"),
+      ])
+   ),
 });
 
 //

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ whats already implemented and what is missing.
 - [x] Type.Literal() via "const" property
 - [x] Type.Union() via "anyOf" property
 - [x] Type.Intersect() via "allOf" property
-- [x] Type.Enum() via "enum" property
+- [x] Type.Union() via "enum" property
 - [x] OneOf() via "oneOf" property
   - This adds oneOf to the typebox type registry as (Kind: 'ExtendedOneOf') in
     order to be able to align to oneOf json schema semantics and still be able
@@ -210,6 +210,14 @@ whats already implemented and what is missing.
       Defaulting to "T" if title is not defined.
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
+
+#### To Be Prioritized
+Support for the following types and functionality is being split from PR #23 into individual PRs
+- [ ] Type.Enum() via "enum" property
+- [ ] Type.Array() with "array<enum>" instance type
+- [ ] Nullable Literal types, eg: `type: ['string', 'null']`
+- [ ] "Unknown" object types
+- [ ] Disambiguation of overlapping property names in nested schemas
 
 ## DEV/CONTRIBUTOR NOTES
 

--- a/examples/basic/generated-typebox.ts
+++ b/examples/basic/generated-typebox.ts
@@ -8,16 +8,16 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });

--- a/examples/programmatic-usage/generated-typebox.ts
+++ b/examples/programmatic-usage/generated-typebox.ts
@@ -8,16 +8,16 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });

--- a/examples/ref-to-relative-files/generated-typebox.ts
+++ b/examples/ref-to-relative-files/generated-typebox.ts
@@ -8,17 +8,17 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum StatusEnum {
-  UNKNOWN = "unknown",
-  ACCEPTED = "accepted",
-  DENIED = "denied",
-}
-
 export type Contract = Static<typeof Contract>;
 export const Contract = Type.Object({
   person: Type.Object({
     name: Type.String({ maxLength: 100 }),
     age: Type.Number({ minimum: 18 }),
   }),
-  status: Type.Optional(Type.Enum(StatusEnum)),
+  status: Type.Optional(
+    Type.Union([
+      Type.Literal("unknown"),
+      Type.Literal("accepted"),
+      Type.Literal("denied"),
+    ])
+  ),
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.9",
-    "@sinclair/typebox": "0.29.0",
+    "@sinclair/typebox": "0.30.2",
     "cosmiconfig": "8.1.3",
     "fp-ts": "2.16.0",
     "minimist": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema2typebox",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "main": "dist/src/index.js",
   "description": "Creates typebox code from JSON schemas",
   "source": "dist/src/index.js",

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { zip } from "fp-ts/Array";
 import $Refparser from "@apidevtools/json-schema-ref-parser";
+import { capitalize } from "./utils";
 
 /** Generates TypeBox code from JSON schema */
 export const schema2typebox = async (jsonSchema: string) => {
@@ -18,16 +19,11 @@ ${customTypes}${enumCode}${typeForObj}\nexport const ${valueName} = ${typeBoxTyp
 };
 
 const generateTypeForName = (name: string) => {
-  const [head, ...tail] = name;
-  if (head === undefined) {
+  if (!name?.length) {
     throw new Error(`Can't generate type for empty string. Got input: ${name}`);
   }
-  if (tail.length === 0) {
-    return `export type ${head.toUpperCase()} = Static<typeof ${name}>`;
-  }
-  return `export type ${head.toUpperCase()}${tail.join(
-    ""
-  )} = Static<typeof ${name}>`;
+  const typeName = capitalize(name);
+  return `export type ${typeName} = Static<typeof ${name}>`;
 };
 
 /**
@@ -121,11 +117,10 @@ const isNotSchemaObj = (
 };
 
 const createEnumName = (propertyName: string) => {
-  const [head, ...tail] = propertyName;
-  if (head === undefined) {
+  if (!propertyName?.length) {
     throw new Error("Can't create enum name with empty string.");
   }
-  return `${head.toUpperCase()}${tail.join("")}Enum`;
+  return `${capitalize(propertyName)}Enum`;
 };
 
 /**

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -141,6 +141,13 @@ export const resetEnumCode = () => {
 };
 
 /**
+ * Used to programatically retrieve the enum code. Used in tests.
+ */
+export const getEnumCode = () => {
+  return enumCode;
+};
+
+/**
  * Adds custom types to the typebox registry in order to validate them and use
  * the typecompiler against them. Used to e.g. implement 'oneOf' which does
  * normally not exist in typebox. This code has the drawback that is does not
@@ -231,19 +238,19 @@ export const collect = (
     );
     const pairs = zip(enumKeys, enumValues);
 
-    const enumName = createEnumName(propertyName);
     // create typescript enum
+    const enumName = createEnumName(propertyName);
     const enumInTypescript =
-    pairs.reduce<string>((prev, [enumKey, enumValue]) => {
-      const correctEnumValue =
-      typeof enumValue === "string" ? `"${enumValue}"` : enumValue;
-      const validEnumKey =
-      enumKey === "" ? "EMPTY_STRING" : enumKey.replace(/[-]/g, "_");
-      return `${prev}${validEnumKey} = ${correctEnumValue},\n`;
-    }, `export enum ${enumName} {\n`) + "}";
+      pairs.reduce<string>((prev, [enumKey, enumValue]) => {
+        const correctEnumValue =
+          typeof enumValue === "string" ? `"${enumValue}"` : enumValue;
+        const validEnumKey =
+          enumKey === "" ? "EMPTY_STRING" : enumKey.replace(/[-]/g, "_");
+        return `${prev}${validEnumKey} = ${correctEnumValue},\n`;
+      }, `export enum ${enumName} {\n`) + "}";
 
     // create typescript union
-    const unionName = createUnionName(propertyName || itemPropertyName || "");
+    const unionName = createUnionName(propertyName);
     const unionInTypescript =
       enumValues.reduce((prev, enumValue) => {
         const correctEnumValue =
@@ -254,8 +261,9 @@ export const collect = (
 
     enumCode = [
       enumCode,
-      /enum/i.test(enumMode) && enumInTypescript,
-      /union/i.test(enumMode) && unionInTypescript,
+      /enum|prefer/i.test(enumMode) && enumInTypescript,
+      /prefer/i.test(enumMode) && "\n",
+      /union|prefer/i.test(enumMode) && unionInTypescript,
       "\n\n",
     ]
       .filter((x) => !!x)

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -179,9 +179,6 @@ export const collect = (
   }
 
   if (isEnumSchemaObj(schemaObj)) {
-    if (propertyName === undefined) {
-      throw new Error("cant create enum without propertyName");
-    }
     let result =
       schemaObj.enum
         .map((enumValue) => {
@@ -198,6 +195,10 @@ export const collect = (
 
     if (!isRequiredAttribute) {
       result = `Type.Optional(${result})`;
+    }
+
+    if (propertyName === undefined) {
+      return result;
     }
     return `${propertyName}: ${result}` + "\n";
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,16 @@
 /**
- * @name capitalize
- * @description
- * Capitalize the first letter of a string
- * @returns {string} The capitalized string
+ * @description Capitalizes the first letter of a string
+ * @throws Error if name is empty string
+ * @returns The capitalized string
  */
 export const capitalize = (name: string) => {
   const [head, ...tail] = name;
-  if (head === undefined) {
-    return name;
+  // just name.length is needed but adding head === undefined check to make
+  // typescript happy
+  if (name.length === 0 || head === undefined) {
+    throw new Error(
+      "Unexpected input when capitalizing. Did not expect empty string."
+    );
   }
   return `${head.toUpperCase()}${tail.join("")}`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * @name capitalize
+ * @description
+ * Capitalize the first letter of a string
+ * @returns {string} The capitalized string
+ */
+export const capitalize = (name: string) => {
+  const [head, ...tail] = name;
+  if (head === undefined) {
+    return name;
+  }
+  return `${head.toUpperCase()}${tail.join("")}`;
+};

--- a/test/index.ts
+++ b/test/index.ts
@@ -864,6 +864,27 @@ describe("schema2typebox internal - collect()", () => {
       expectedTypebox
     );
   });
+  test("enum schema", async () => {
+    const dummySchema = `
+    {
+      "title": "Status",
+      "enum": ["unknown", "accepted", "denied"]
+    }
+    `;
+    const expectedTypebox = `
+    Type.Optional(
+      Type.Union([
+        Type.Literal("unknown"),
+        Type.Literal("accepted"),
+        Type.Literal("denied"),
+      ])
+    );
+    `;
+    expectEqualIgnoreFormatting(
+      collect(JSON.parse(dummySchema)),
+      expectedTypebox
+    );
+  });
 });
 
 // NOTE: these are the most "high level" tests. Create them sparsely. Focus on

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:0.29.0":
-  version: 0.29.0
-  resolution: "@sinclair/typebox@npm:0.29.0"
-  checksum: eefe2217c7e18b4f5c0ba4a345f371fdcd1092faf1905a7cf9c758aebbae73500bec16c68beab39a735cba1f0a758963997a4780adefb7ce67934b87f80ef747
+"@sinclair/typebox@npm:0.30.2":
+  version: 0.30.2
+  resolution: "@sinclair/typebox@npm:0.30.2"
+  checksum: ddb5368b6a11b953edd511d62e4b575c46bafabcc7de815f64be7f34dbfc63649ef1651c0687af952ac6a9b3aba03d2f91ec0dd9ec7d8a1ca24e35b4d6e60ac9
   languageName: node
   linkType: hard
 
@@ -2505,7 +2505,7 @@ __metadata:
   resolution: "schema2typebox@workspace:."
   dependencies:
     "@apidevtools/json-schema-ref-parser": 9.0.9
-    "@sinclair/typebox": 0.29.0
+    "@sinclair/typebox": 0.30.2
     "@tsconfig/node18": 2.0.0
     "@types/minimist": 1.2.2
     "@types/node": 18.16.8


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Before submitting it, please make sure that you added a test case for the bug
that you fixed, or new feature that you added. This is required.

-->

## Summary

@pdfowler  Hey!

First of, sorry for not commenting your PR but rather directly adapting it. The main changes were simply based on the decision to only support Type.Union instead of enums and unions for now. I added you as a colaborator to the repo so you can review this PR. Please wait for my approval when merging PRs. I will merge this one after a while if you have no time for a review.

Adapting the work of @pdfowler to my preference/decision of generating union types (and only union types for now) for JSON schema objects of type "enum".
My main reasons for this decision:
- it makes the code way easier to maintain (as reflected by the diff in [this commit](https://github.com/xddq/schema2typebox/pull/26/commits/1c3381d670b63842d6ee2c8a8d9a869d5a133bf1#diff-1a0938f299d1ba9e99ef216453f7b958914e7afa6752b9206e541b4851eb1cef)). The codegen code gets easier, less dirty global state, easier testing. The decision to use global state for the enum code was painful for me anyway but I decided to do it to get the feature done. The pain is somewhat reflected in the initial comment [here](https://github.com/xddq/schema2typebox/blob/main/src/schema-to-typebox.ts#L140) and [here](https://github.com/xddq/schema2typebox/blob/main/test/index.ts#L44) but I was to lazy to adapt the collect code.
- I agree on the mentioned state of enums in Typescript mentioned by a comment [here](https://github.com/xddq/schema2typebox/pull/23/files#diff-1a0938f299d1ba9e99ef216453f7b958914e7afa6752b9206e541b4851eb1cefR170). I want to push for using unions as thats what I commonly use and see anyway.

If this PR is merged the pr [here](https://github.com/xddq/schema2typebox/pull/24) will be closed.

After merge a new release (1.5.0) will be created.