### PR TITLE
ensure generation of $id as schema option in resulting typebox code

### DIFF
--- a/tasks.mjs
+++ b/tasks.mjs
@@ -29,7 +29,9 @@ export const test = () => {
   build();
   // runs tests based on the test runner execution model
   // src: https://nodejs.org/api/test.html#test-runner-execution-model"
-  const { code } = shell.exec(`node --test --test-reporter spec`);
+  const { code } = shell.exec(
+    `node --enable-source-maps --test --test-reporter spec`
+  );
   handleNonZeroReturnCode(code);
 };
 

--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -23,6 +23,6 @@ describe("integration tests - testing against real world schemas", () => {
       ]),
       "utf-8"
     );
-    expectEqualIgnoreFormatting(result, expectedResult);
+    await expectEqualIgnoreFormatting(result, expectedResult);
   });
 });

--- a/test/integration/schemas/dayOfWeek.ts
+++ b/test/integration/schemas/dayOfWeek.ts
@@ -69,7 +69,6 @@ export const DayOfWeek = OneOf(
   {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     $id: "schema:DayOfWeek",
-    title: "DayOfWeek",
     description:
       "The day of the week, e.g. used to specify to which day the opening hours of an OpeningHoursSpecification refer.\n\nOriginally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were used (for [[Monday]], [[Tuesday]], [[Wednesday]], [[Thursday]], [[Friday]], [[Saturday]], [[Sunday]] plus a special entry for [[PublicHolidays]]); these have now been integrated directly into schema.org.\n      ",
   }

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -53,6 +53,24 @@ describe("parser unit tests", () => {
       const expectedResult = `Type.Object({a: Type.Optional(Type.Number()),\n b: Type.String()})`;
       await expectEqualIgnoreFormatting(result, expectedResult);
     });
+    it("creates code with schemaOptions", async () => {
+      const dummySchema: ObjectSchema = {
+        $id: "AnyStringHere",
+        type: "object",
+        properties: {
+          a: {
+            type: "number",
+          },
+          b: {
+            type: "string",
+          },
+        },
+        required: ["b"],
+      };
+      const result = parseObject(dummySchema);
+      const expectedResult = `Type.Object({a: Type.Optional(Type.Number()),\n b: Type.String()}, { $id: "AnyStringHere" })`;
+      await expectEqualIgnoreFormatting(expectedResult, result);
+    });
   });
 
   describe("parseEnum() - when parsing an enum schema", () => {
@@ -63,6 +81,16 @@ describe("parser unit tests", () => {
       };
       const result = parseEnum(dummySchema);
       expect(result).to.contain("Type.Union");
+    });
+    it("creates code with schemaOptions", () => {
+      const dummySchema: EnumSchema = {
+        $id: "AnyStringHere",
+        title: "Status",
+        enum: ["unknown", 1, null],
+      };
+      const result = parseEnum(dummySchema);
+      expect(result).to.contain("Type.Union");
+      expect(result).to.contain('{"$id":"AnyStringHere"}');
     });
   });
 
@@ -96,6 +124,22 @@ describe("parser unit tests", () => {
       expect(result).to.contain("Type.String()");
       expect(result).to.contain("Type.Number()");
     });
+    it("creates code with schemaOptions", () => {
+      const dummySchema: AnyOfSchema = {
+        $id: "AnyStringHere",
+        anyOf: [
+          {
+            type: "string",
+          },
+          {
+            type: "number",
+          },
+        ],
+      };
+      const result = parseAnyOf(dummySchema);
+      expect(result).to.contain("Type.Union");
+      expect(result).to.contain('{"$id":"AnyStringHere"}');
+    });
   });
 
   describe("parseAllOf() - when parsing an allOf schema", () => {
@@ -124,6 +168,18 @@ describe("parser unit tests", () => {
       const result = parseAllOf(schema);
       expect(result).to.contain(`Type.String()`);
       expect(result).to.contain(`Type.Number()`);
+    });
+    it("creates code with schemaOptions", () => {
+      const schema: AllOfSchema = {
+        $id: "AnyStringHere",
+        allOf: [
+          {
+            type: "string",
+          },
+        ],
+      };
+      const result = parseAllOf(schema);
+      expect(result).to.contain('{"$id":"AnyStringHere"}');
     });
   });
 
@@ -154,6 +210,18 @@ describe("parser unit tests", () => {
       expect(result).to.contain(`Type.String()`);
       expect(result).to.contain(`Type.Number()`);
     });
+    it("creates code with schemaOptions", () => {
+      const schema: OneOfSchema = {
+        $id: "AnyStringHere",
+        oneOf: [
+          {
+            type: "string",
+          },
+        ],
+      };
+      const result = parseOneOf(schema);
+      expect(result).to.contain('{"$id":"AnyStringHere"}');
+    });
   });
 
   describe("parseNot() - when parsing a not schema", () => {
@@ -165,6 +233,16 @@ describe("parser unit tests", () => {
       };
       const result = parseNot(schema);
       expect(result).to.contain(`Type.Not`);
+    });
+    it("creates code with schemaOptions", () => {
+      const schema: NotSchema = {
+        $id: "AnyStringHere",
+        not: {
+          type: "number",
+        },
+      };
+      const result = parseNot(schema);
+      expect(result).to.contain('{"$id":"AnyStringHere"}');
     });
   });
 

--- a/test/programmatic-usage.spec.ts
+++ b/test/programmatic-usage.spec.ts
@@ -33,7 +33,7 @@ describe("programmatic usage - when running the programmatic usage", async () =>
     import { Static, Type } from "@sinclair/typebox";
 
     export type Contract = Static<typeof Contract>;
-    export const Contract = Type.Object({name: Type.String()});
+    export const Contract = Type.Object({name: Type.String()}, { $id: "Contract" });
     `);
     await expectEqualIgnoreFormatting(
       await schema2typebox({ input: dummySchema }),
@@ -100,7 +100,8 @@ describe("programmatic usage - when running the programmatic usage", async () =>
             Type.Literal("denied"),
           ])
         ),
-      });
+      },
+      { $id: "Contract" });
     `);
 
       const inputPaths = ["person.json", "status.json"].flatMap((currItem) => {
@@ -170,7 +171,8 @@ describe("programmatic usage - when running the programmatic usage", async () =>
           type: Type.Literal("dog"),
           name: Type.String({ maxLength: 100 }),
         }),
-      ]);
+      ],
+      { $id: "T" });
     `);
 
       const inputPaths = ["cat.json", "dog.json"].flatMap((currItem) => {
@@ -209,16 +211,19 @@ describe("programmatic usage - when running the programmatic usage", async () =>
       import { Static, Type } from "@sinclair/typebox";
 
       export type T = Static<typeof T>;
-      export const T = Type.Union([
-        Type.Object({
-          type: Type.Literal("cat"),
-          name: Type.String({ maxLength: 100 }),
-        }),
-        Type.Object({
-          type: Type.Literal("dog"),
-          name: Type.String({ maxLength: 100 }),
-        }),
-      ]);
+      export const T = Type.Union(
+        [
+          Type.Object({
+            type: Type.Literal("cat"),
+            name: Type.String({ maxLength: 100 }),
+          }),
+          Type.Object({
+            type: Type.Literal("dog"),
+            name: Type.String({ maxLength: 100 }),
+          }),
+        ],
+        { $id: "T" }
+      );
     `);
 
       await expectEqualIgnoreFormatting(
@@ -275,7 +280,10 @@ describe("programmatic usage - when running the programmatic usage", async () =>
       ) => Type.Unsafe<Static<TUnion<T>>>({ ...options, [Kind]: "ExtendedOneOf", oneOf });
 
       export type T = Static<typeof T>;
-      export const T = Type.Object({a: OneOf([Type.String(), Type.Number()])});
+      export const T = Type.Object(
+        { a: OneOf([Type.String(), Type.Number()]) },
+        { $id: "T" }
+      );
     `);
     await expectEqualIgnoreFormatting(
       await schema2typebox({ input: dummySchema }),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Before submitting it, please make sure that you added a test case for the bug
that you fixed, or new feature that you added. This is required.

-->

## Summary

Based on issue #32 . This ensures that the generated typebox code will always contain an $id property.
Additional test cases for checking the schemaOptions were added

<!--
 What did you do? Link the issue or discussion your PR is based on. Why are you
making this change?
-->
