### PR TITLE
Quote object literal property names when required

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# 1.7.1
+
+- fix typebox code generation for JSON schemas which use property names like
+  (without the quotes) "@test", "1", or "some with spaces".
+
+[src](https://github.com/xddq/schema2typebox/pull/36)
+
 # 1.7.0
 
 - ensure generation of $id as schema option in resulting typebox code (#33)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema2typebox",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "dist/src/index.js",
   "description": "Creates typebox code from JSON schemas",
   "source": "dist/src/index.js",

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -151,6 +151,11 @@ const addOptionalModifier = (
     : `Type.Optional(${code})`;
 };
 
+const propertyNameLiteral = (name: string): string => {
+  const asciiLiteral = /^[A-Za-z_$][\w$]*/;
+  return asciiLiteral.test(name) ? name : `"${name.replaceAll('"', '\\"')}"`;
+}
+
 export const parseObject = (schema: ObjectSchema) => {
   const schemaOptions = parseSchemaOptions(schema);
   const properties = schema.properties;
@@ -162,7 +167,7 @@ export const parseObject = (schema: ObjectSchema) => {
   const code = attributes.reduce<string>((acc, [propertyName, schema]) => {
     return (
       acc +
-      `${acc === "" ? "" : ",\n"}${propertyName}: ${addOptionalModifier(
+      `${acc === "" ? "" : ",\n"}${propertyNameLiteral(propertyName)}: ${addOptionalModifier(
         collect(schema),
         propertyName,
         requiredProperties

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -53,6 +53,32 @@ describe("parser unit tests", () => {
       const expectedResult = `Type.Object({a: Type.Optional(Type.Number()),\n b: Type.String()})`;
       await expectEqualIgnoreFormatting(result, expectedResult);
     });
+    it("quotes property names when required", async () => {
+      const dummySchema: ObjectSchema = {
+        type: "object",
+        properties: {
+          "@prop": {
+            type: "string",
+          },
+          "6": {
+            type: "boolean",
+          },
+          unquoted: {
+            type: "number",
+          },
+          __underscores: {
+            type: "string",
+          },
+          " spaces are \"weirdly\" valid ": {
+            type: "number"
+          },
+        },
+        required: ["@prop", "6", "unquoted", "__underscores", " spaces are \"weirdly\" valid "],
+      };
+      const result = parseObject(dummySchema);
+      const expectedResult = `Type.Object({"6": Type.Boolean(),\n "@prop": Type.String(),\n unquoted: Type.Number(),\n __underscores: Type.String(),\n " spaces are \\"weirdly\\" valid ": Type.Number()})`;
+      await expectEqualIgnoreFormatting(result, expectedResult);
+    });
     it("creates code with schemaOptions", async () => {
       const dummySchema: ObjectSchema = {
         $id: "AnyStringHere",

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -69,14 +69,20 @@ describe("parser unit tests", () => {
           __underscores: {
             type: "string",
           },
-          " spaces are \"weirdly\" valid ": {
-            type: "number"
+          " spaces are weirdly valid ": {
+            type: "number",
           },
         },
-        required: ["@prop", "6", "unquoted", "__underscores", " spaces are \"weirdly\" valid "],
+        required: [
+          "@prop",
+          "6",
+          "unquoted",
+          "__underscores",
+          " spaces are weirdly valid ",
+        ],
       };
       const result = parseObject(dummySchema);
-      const expectedResult = `Type.Object({"6": Type.Boolean(),\n "@prop": Type.String(),\n unquoted: Type.Number(),\n __underscores: Type.String(),\n " spaces are \\"weirdly\\" valid ": Type.Number()})`;
+      const expectedResult = `Type.Object({"6": Type.Boolean(),\n "@prop": Type.String(),\n unquoted: Type.Number(),\n __underscores: Type.String(),\n " spaces are weirdly valid ": Type.Number()})`;
       await expectEqualIgnoreFormatting(result, expectedResult);
     });
     it("creates code with schemaOptions", async () => {


### PR DESCRIPTION
## Quote object literal property names when required

In a JS/TS object literal, there are some restrictions on the definition of a property name. For example, this is not a valid object literal:
```
const cat = {
   9_lives: true
};
```
because a property name literal is not allowed to begin with a digit. To work around this, we can use a string literal for the property name:
```
const cat = {
  "9_lives": true
};
```

If a schema happens to define an object property that requires wrapping quotes, the generated Typescript code isn't currently syntactically correct.

Discussion link: https://github.com/xddq/schema2typebox/discussions/35