### PR TITLE
feat: :sparkles: handle patternProperties and create record type

### DIFF
--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -166,6 +166,20 @@ export const parseObject = (schema: ObjectSchema) => {
   const properties = schema.properties;
   const requiredProperties = schema.required;
   if (properties === undefined) {
+    if (schema.patternProperties) {
+      const records: string[] = [];
+      for (const value of Object.values(schema.patternProperties)) {
+        if (typeof value === "object") {
+          records.push(`Type.Record(Type.String(), ${collect(value)})`);
+        }
+      }
+      if (records.length === 1) {
+        return `${records[0]}`;
+      } else if (records.length > 1) {
+        return `Type.Union([${records.join(", ")}])`;
+      }
+    }
+
     return `Type.Unknown()`;
   }
   const attributes = Object.entries(properties);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -103,6 +103,34 @@ describe("parser unit tests", () => {
       const expectedResult = `Type.Object({a: Type.Optional(Type.Number()),\n b: Type.String()}, { $id: "AnyStringHere" })`;
       await expectEqualIgnoreFormatting(expectedResult, result);
     });
+    it("create a record type if patternProperties is present (array)", async () => {
+      const dummySchema: ObjectSchema = {
+        type: "object",
+        patternProperties: {
+          "^(.*)$": {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      };
+      const result = parseObject(dummySchema);
+      const expectedResult = `Type.Record(Type.String(), Type.Array(Type.String()))`;
+      await expectEqualIgnoreFormatting(expectedResult, result);
+    });
+    it("create an union with record types if patternProperties with multiple keys is present", async () => {
+      const dummySchema: ObjectSchema = {
+        type: "object",
+        patternProperties: {
+          "^S_": { type: "string" },
+          "^I_": { type: "integer" },
+        },
+      };
+      const result = parseObject(dummySchema);
+      const expectedResult = `Type.Union([Type.Record(Type.String(), Type.String()), Type.Record(Type.String(), Type.Number())])`;
+      await expectEqualIgnoreFormatting(expectedResult, result);
+    });
   });
 
   describe("parseEnum() - when parsing an enum schema", () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Before submitting it, please make sure that you added a test case for the bug
that you fixed, or new feature that you added. This is required.

-->

## Summary

Handle JSON Schema patternProperties[^1] to be able to create a type of `Record`.

[^1]: https://json-schema.org/understanding-json-schema/reference/object#patternProperties

<!--
 What did you do? Link the issue or discussion your PR is based on. Why are you
making this change?
-->
