### PR TITLE
fix: add support for unions containing arrays or objects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,23 @@
+# 1.7.3
+
+- support unions containing objects and/or arrays
+
+  ```json
+  { 
+    "type": "object",
+    "properties":  {
+      "nullableObject": {
+        "type": ["object", "null"],
+        "properties": {}
+      },
+      "nullableArray": {
+        "type": ["array", "null"],
+        "items": {}
+      }
+    }
+  }
+  ```
+  
 # 1.7.2
 
 - allow array schemas that don't specify a type for the array items. [src](https://github.com/xddq/schema2typebox/pull/42)

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -291,13 +291,13 @@ export const parseArray = (schema: ArraySchema): Code => {
 
 export const parseWithMultipleTypes = (schema: MultipleTypesSchema): Code => {
   const code = schema.type.reduce<string>((acc, typeName) => {
-    return acc + `${acc === "" ? "" : ",\n"} ${parseTypeName(typeName)}`;
+    return acc + `${acc === "" ? "" : ",\n"} ${parseTypeName(typeName, schema)}`;
   }, "");
   return `Type.Union([${code}])`;
 };
 
 export const parseTypeName = (
-  type: Omit<JSONSchema7TypeName, "array" | "object">,
+  type: JSONSchema7TypeName,
   schema: JSONSchema7 = {}
 ): Code => {
   const schemaOptions = parseSchemaOptions(schema);
@@ -317,6 +317,12 @@ export const parseTypeName = (
     return schemaOptions === undefined
       ? "Type.Null()"
       : `Type.Null(${schemaOptions})`;
+  } else if (type === "object") {
+    return parseObject(schema as ObjectSchema)
+  // We don't want to trust on build time checking here, json can contain anything
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  } else if (type === "array") {
+     return parseArray(schema as ArraySchema)
   }
   throw new Error(`Should never happen..? parseType got type: ${type}`);
 };

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -370,6 +370,28 @@ describe("parser unit tests", () => {
       expect(result).to.contain(`Type.String`);
       expect(result).to.contain(`Type.Null`);
     });
+
+    it("creates union types for nullable objects", () => {
+      const schema: MultipleTypesSchema = {
+        type: ["object", "null"],
+        properties: {},
+      };
+      const result = parseWithMultipleTypes(schema);
+      expect(result).to.contain(`Type.Union`);
+      expect(result).to.contain(`Type.Object({})`);
+      expect(result).to.contain(`Type.Null`);
+    });
+
+    it("creates union types for nullable arrays", () => {
+      const schema: MultipleTypesSchema = {
+        type: ["array", "null"],
+        items: { type: "string" },
+      };
+      const result = parseWithMultipleTypes(schema);
+      expect(result).to.contain(`Type.Union`);
+      expect(result).to.contain(`Type.Array(Type.String())`);
+      expect(result).to.contain(`Type.Null`);
+    })
   });
 
   describe("parseConst() - when parsing a const schema", () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Before submitting it, please make sure that you added a test case for the bug
that you fixed, or new feature that you added. This is required.

-->

## Summary

This adds support for unions that have an array or object in them, like in the schema below. 

Other unions like `[string, null]` were already supported. Unions with arrays `[array, null]` and objects `[object, null]` were not. Tests covering these new cases are included.

```js
{
  type: "object",
  properties: {
    nullableObject: {
      type: ["object", "null"],
      properties: {
        name: { type: "string" },
      }
    },
    nullableArray: {
      type: ["array", "null"],
      items: {
        type: "string"
      },
    },
  }
});
```

<!--
 What did you do? Link the issue or discussion your PR is based on. Why are you
making this change?
-->

I'm making this change, because we have schemas with nullable arrays and objects. Without this change, those schemas cannot be parsed.

Fixes #43 