### PR TITLE
fix: quote property names containing hyphens

### DIFF
--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -157,7 +157,7 @@ const addOptionalModifier = (
  * Returns the property name wrapped in quotes whenever quotes are required.
  */
 export const quotePropertyNameWhenRequired = (propertyName: string) => {
-  const quotingIsNotRequired = /^[A-Za-z_$].*/.test(propertyName);
+  const quotingIsNotRequired = /^[A-Za-z_]*$/.test(propertyName);
   return quotingIsNotRequired ? propertyName : `"${propertyName}"`;
 };
 

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -72,6 +72,9 @@ describe("parser unit tests", () => {
           " spaces are weirdly valid ": {
             type: "number",
           },
+          "with-hyphen": {
+            type: "string",
+          }
         },
         required: [
           "@prop",
@@ -79,10 +82,11 @@ describe("parser unit tests", () => {
           "unquoted",
           "__underscores",
           " spaces are weirdly valid ",
+          "with-hyphen",
         ],
       };
       const result = parseObject(dummySchema);
-      const expectedResult = `Type.Object({"6": Type.Boolean(),\n "@prop": Type.String(),\n unquoted: Type.Number(),\n __underscores: Type.String(),\n " spaces are weirdly valid ": Type.Number()})`;
+      const expectedResult = `Type.Object({"6": Type.Boolean(),\n "@prop": Type.String(),\n unquoted: Type.Number(),\n __underscores: Type.String(),\n " spaces are weirdly valid ": Type.Number(),\n "with-hyphen": Type.String()})`;
       await expectEqualIgnoreFormatting(result, expectedResult);
     });
     it("creates code with schemaOptions", async () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!

  Before submitting it, please make sure that you added a test case for the bug
that you fixed, or new feature that you added. This is required.

-->

## Summary

The regex to test property names wasn't right. This fixes it and thereby also quotes property names with hyphens, like `car-brand`.

Fixes #45 

<!--
 What did you do? Link the issue or discussion your PR is based on. Why are you
making this change?
-->
