### PR TITLE
Support titles containing spaces, dots, dashes or underscores

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 1.7.5
 
+- support `title` fields with spaces [src](https://github.com/xddq/schema2typebox/pull/53)
+
+# 1.7.5
+
 - parse {} as Type.Unknown() [src](https://github.com/xddq/schema2typebox/pull/51)
 
 # 1.7.4

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # 1.7.5
 
-- support `title` fields with spaces [src](https://github.com/xddq/schema2typebox/pull/53)
+- support `title` fields containing characters '- .\_' [src](https://github.com/xddq/schema2typebox/pull/53)
 
 # 1.7.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema2typebox",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "main": "dist/src/index.js",
   "description": "Creates typebox code from JSON schemas",
   "source": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.9",
+    "camelcase": "6.3.0",
     "cosmiconfig": "8.1.3",
     "fp-ts": "2.16.0",
     "minimist": "1.2.8",

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -126,7 +126,12 @@ const createExportNameForSchema = (schema: JSONSchema7Definition) => {
   if (isBoolean(schema)) {
     return "T";
   }
-  return toPascalCase(schema["title"] ?? "T");
+  const title = schema["title"] ?? "T";
+  // only convert to PascalCase if there is a space in the name for backwards compatibility
+  if (title.includes(" ")) {
+    return toPascalCase(title);
+  }
+  return title;
 };
 
 /**

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -1,4 +1,5 @@
 import $Refparser from "@apidevtools/json-schema-ref-parser";
+import camelcase from "camelcase";
 import { isBoolean } from "fp-ts/lib/boolean";
 import { isNumber } from "fp-ts/lib/number";
 import { isString } from "fp-ts/lib/string";
@@ -112,24 +113,20 @@ const createImportStatements = () => {
   ].join("\n");
 };
 
-const toPascalCase = (str: string) => {
-  return str
-    .split(/[\s_]+/) // split on spaces or underscores
-    .filter(Boolean) // remove empty strings
-    .map(word => {
-      return word.charAt(0).toUpperCase() + word.slice(1)
-    })
-    .join('')
-};
-
 const createExportNameForSchema = (schema: JSONSchema7Definition) => {
   if (isBoolean(schema)) {
     return "T";
   }
   const title = schema["title"] ?? "T";
-  // only convert to PascalCase if there is a space in the name for backwards compatibility
-  if (title.includes(" ")) {
-    return toPascalCase(title);
+  // converting these cases to pascalCase to ensure the resulting name is a
+  // valid name for a typescript type. Based on: https://github.com/xddq/schema2typebox/pull/53
+  if (
+    title.includes(" ") ||
+    title.includes("-") ||
+    title.includes("_") ||
+    title.includes(".")
+  ) {
+    return camelcase(title, { pascalCase: true });
   }
   return title;
 };

--- a/src/schema-to-typebox.ts
+++ b/src/schema-to-typebox.ts
@@ -112,11 +112,21 @@ const createImportStatements = () => {
   ].join("\n");
 };
 
+const toPascalCase = (str: string) => {
+  return str
+    .split(/[\s_]+/) // split on spaces or underscores
+    .filter(Boolean) // remove empty strings
+    .map(word => {
+      return word.charAt(0).toUpperCase() + word.slice(1)
+    })
+    .join('')
+};
+
 const createExportNameForSchema = (schema: JSONSchema7Definition) => {
   if (isBoolean(schema)) {
     return "T";
   }
-  return schema["title"] ?? "T";
+  return toPascalCase(schema["title"] ?? "T");
 };
 
 /**

--- a/test/programmatic-usage.spec.ts
+++ b/test/programmatic-usage.spec.ts
@@ -12,10 +12,18 @@ import { buildOsIndependentPath, expectEqualIgnoreFormatting } from "./util";
 const SHELLJS_RETURN_CODE_OK = 0;
 
 describe("when running the programmatic usage", () => {
-  test("generated typebox names are based on title attribute", async () => {
-    const dummySchema = `
+  describe("when generating typescript type and typebox value names", () => {
+    test.each([
+      { title: "Dummy-Title", expectedName: "DummyTitle" },
+      { title: "dummy Title", expectedName: "DummyTitle" },
+      { title: "dummy_title", expectedName: "DummyTitle" },
+      { title: "dummy.title", expectedName: "DummyTitle" },
+    ])(
+      "generates PascalCase when title contains at least one of '. -_' characters. testing with: $title expecting: $expectedName",
+      async ({ title, expectedName }) => {
+        const dummySchema = `
     {
-      "title": "Contract",
+      "title": "${title}",
       "type": "object",
       "properties": {
         "name": {
@@ -25,21 +33,28 @@ describe("when running the programmatic usage", () => {
       "required": ["name"]
     }
     `;
-    const expectedTypebox = addCommentThatCodeIsGenerated(`
+        const expectedTypebox = addCommentThatCodeIsGenerated(`
     import { Static, Type } from "@sinclair/typebox";
 
-    export type Contract = Static<typeof Contract>;
-    export const Contract = Type.Object({name: Type.String()}, { $id: "Contract" });
+    export type ${expectedName} = Static<typeof ${expectedName}>;
+    export const ${expectedName} = Type.Object({name: Type.String()}, { $id: "${expectedName}" });
     `);
-    await expectEqualIgnoreFormatting(
-      await schema2typebox({ input: dummySchema }),
-      expectedTypebox
+        await expectEqualIgnoreFormatting(
+          await schema2typebox({ input: dummySchema }),
+          expectedTypebox
+        );
+      }
     );
-  });
-  test("generated typebox name based on title attribute support spacing", async () => {
-    const dummySchema = `
+    test.each([
+      { title: "dummyTitle", expectedName: "DummyTitle" },
+      { title: "DummyTitle", expectedName: "DummyTitle" },
+      { title: "dummytitle", expectedName: "Dummytitle" },
+    ])(
+      "enforces capitel character and keeps the rest when title does not contain any characters of '. -_'. testing with: $title expecting: $expectedName",
+      async ({ title, expectedName }) => {
+        const dummySchema = `
     {
-      "title": "My Contract",
+      "title": "${title}",
       "type": "object",
       "properties": {
         "name": {
@@ -49,15 +64,17 @@ describe("when running the programmatic usage", () => {
       "required": ["name"]
     }
     `;
-    const expectedTypebox = addCommentThatCodeIsGenerated(`
+        const expectedTypebox = addCommentThatCodeIsGenerated(`
     import { Static, Type } from "@sinclair/typebox";
 
-    export type MyContract = Static<typeof MyContract>;
-    export const MyContract = Type.Object({name: Type.String()}, { $id: "MyContract" });
+    export type ${expectedName} = Static<typeof ${title}>;
+    export const ${title} = Type.Object({name: Type.String()}, { $id: "${title}" });
     `);
-    await expectEqualIgnoreFormatting(
-      await schema2typebox({ input: dummySchema }),
-      expectedTypebox
+        await expectEqualIgnoreFormatting(
+          await schema2typebox({ input: dummySchema }),
+          expectedTypebox
+        );
+      }
     );
   });
   describe("when working with files containing $refs (sanity check of refparser library)", () => {

--- a/test/programmatic-usage.spec.ts
+++ b/test/programmatic-usage.spec.ts
@@ -36,6 +36,30 @@ describe("when running the programmatic usage", () => {
       expectedTypebox
     );
   });
+  test("generated typebox name based on title attribute support spacing", async () => {
+    const dummySchema = `
+    {
+      "title": "My Contract",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+    `;
+    const expectedTypebox = addCommentThatCodeIsGenerated(`
+    import { Static, Type } from "@sinclair/typebox";
+
+    export type MyContract = Static<typeof MyContract>;
+    export const MyContract = Type.Object({name: Type.String()}, { $id: "MyContract" });
+    `);
+    await expectEqualIgnoreFormatting(
+      await schema2typebox({ input: dummySchema }),
+      expectedTypebox
+    );
+  });
   describe("when working with files containing $refs (sanity check of refparser library)", () => {
     test("object with $ref pointing to external files in relative path", async () => {
       const dummySchema = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,17 +2557,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:6.3.0, camelcase@npm:^6.2.0":
+  version: 6.3.0
+  resolution: "camelcase@npm:6.3.0"
+  checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
-  languageName: node
-  linkType: hard
-
-"camelcase@npm:^6.2.0":
-  version: 6.3.0
-  resolution: "camelcase@npm:6.3.0"
-  checksum: 8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
   languageName: node
   linkType: hard
 
@@ -5224,6 +5224,7 @@ __metadata:
     "@types/shelljs": 0.8.12
     "@typescript-eslint/eslint-plugin": 5.59.6
     "@typescript-eslint/parser": 5.59.6
+    camelcase: 6.3.0
     concurrently: 7.6.0
     cosmiconfig: 8.1.3
     eslint: 8.40.0


### PR DESCRIPTION
## Summary

Schemas where the title had a space in it (ex: `"title": "My Contract"`) generated invalid code 

```ts
export type My Contract // note: a space here makes it an invalid identifier
```

To fix this, I instead convert the string into pascal case (the naming standard used for TS type names)